### PR TITLE
[JSYNC-23] Check race condition with github.event.release.tag_name

### DIFF
--- a/.github/workflows/jirafy-sync.yml
+++ b/.github/workflows/jirafy-sync.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./
         with:
           changelog: ${{ steps.changelog.outputs.changelog }}
-          jiraVersion: ${{ github.ref }}
+          jiraVersion: ${{ github.event.release.tag_name }}
           jiraHost: 'coltdorsey.atlassian.net'
           jiraUsername: ${{ secrets.JIRA_USERNAME }}
           jiraToken: ${{ secrets.JIRA_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jirafy-sync",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jirafy-sync",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jirafy-sync",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Sync Jira tickets and version based on a given changelog",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- Trying github.event.release.tag_name for jiraVersion. Possible race condition