### PR TITLE
[sdet-527] update regex for omitting branch names

### DIFF
--- a/.github/workflows/jirafy-sync.yml
+++ b/.github/workflows/jirafy-sync.yml
@@ -15,9 +15,9 @@ jobs:
       # Generate changelog optimized for referenced Jira Tickets from Pull Request titles
       - name: Jirafy Changelog
         id: changelog
-        uses: onXmaps/jirafy-changelog@v1.1.0
+        uses: onXmaps/jirafy-changelog@v1.2.0
         with:
-          jiraHost: 'coltdorsey.atlassian.net'
+          jiraHost: ${{ secrets.JIRA_HOST }}
           myToken: ${{ secrets.GITHUB_TOKEN }}
 
       # Create a release
@@ -46,6 +46,6 @@ jobs:
         with:
           changelog: ${{ steps.changelog.outputs.changelog }}
           jiraVersion: ${{ github.ref_name }}
-          jiraHost: 'coltdorsey.atlassian.net'
+          jiraHost: ${{ secrets.JIRA_HOST }}
           jiraUsername: ${{ secrets.JIRA_USERNAME }}
           jiraToken: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-      JIRA_HOST: 'coltdorsey.atlassian.net'
+      JIRA_HOST: ${{ secrets.JIRA_HOST }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ jobs:
       JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
       JIRA_HOST: ${{ secrets.JIRA_HOST }}
+      PROJECT_ID: ${{ secrets.PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ jobs:
 
       - name: Jirafy Changelog
         id: changelog
-        uses: onXmaps/jirafy-changelog@v1.1.0
+        uses: onXmaps/jirafy-changelog@v1.2.0
         with:
           jiraHost: 'example.atlassian.net'
           myToken: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ jobs:
           prerelease: false
 
       - name: Jirafy Sync
-        uses: onXmaps/jirafy-sync@v2.0.1
+        uses: onXmaps/jirafy-sync@v2.1.0
         with:
           changelog: ${{ steps.changelog.outputs.changelog }}
           jiraVersion: ${{ github.ref_name }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -57917,7 +57917,7 @@ function parseChangelogForJiraTickets(changelog) {
   var tickets
 
   try {
-    const regex = /([A-Za-z0-9]+-\d+)/g
+    const regex = /([A-Za-z0-9]+-\d+)(?=`)/g
     tickets = [...changelog.matchAll(regex)]
   } catch (error) {
     core.setFailed(error.message)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jirafy-sync",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jirafy-sync",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jirafy-sync",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Sync Jira tickets and version based on a given changelog",
   "main": "dist/index.js",
   "scripts": {

--- a/test/jirafy-sync.spec.js
+++ b/test/jirafy-sync.spec.js
@@ -19,15 +19,13 @@ describe('Jirafy Sync', () => {
   * [`ce73404`](http://github.com/onXmaps/jirafy-changelog/commit/ce73404ce5cb38c9c6a86b6188a790e76a7575fb)  [`SDET-486`](https://coltdorsey.atlassian.net/browse/SDET-486) Updating references - Merge pull request #22 from onXmaps/colt/update-references'
 
   before(() => {
-    core.setSecret('projectId')
-    projectId = process.env.PROJECT_ID
+    projectId = core.getInput('PROJECT_ID') || process.env.PROJECT_ID
   })
 
   context('Jira Projects', () => {
     it('Ensure jira project keys are always uppercase', async () => {
       var resp = await jira.getProjectIdByKey(key.toLowerCase())
-      chai.assert.equal(resp, process.env.PROJECT_ID || projectId)
-      core.set
+      chai.assert.equal(resp, projectId)
     })
 
     it('Ensure project retrieval error message', async () => {
@@ -37,7 +35,7 @@ describe('Jirafy Sync', () => {
 
     it('Ensure project retrieval success', async () => {
       var resp = await jira.getProjectIdByKey(key)
-      chai.assert.equal(resp, process.env.PROJECT_ID || projectId)
+      chai.assert.equal(resp, projectId)
     })
   })
 

--- a/test/jirafy-sync.spec.js
+++ b/test/jirafy-sync.spec.js
@@ -2,10 +2,12 @@ require('dotenv').config()
 const jira = require('../utils/jira')
 const { parseChangelogForJiraTickets } = require('../utils/jira-helper')
 const chai = require('chai')
+const core = require('@actions/core')
 const key = 'SDET'
 const badKey = 'arglebargle'
 
 describe('Jirafy Sync', () => {
+  var projectId
   var changelog =
     '* [`4f94449`](http://github.com/onXmaps/jirafy-changelog/commit/4f94449419698e134785e58ceac74702ab47781b)  [`JIRAFY-5`](https://coltdorsey.atlassian.net/browse/JIRAFY-5) Readme example release update - Merge pull request #5 from coltdorsey/colt/readme-example-release \
   * [`58e69be`](http://github.com/onXmaps/jirafy-changelog/commit/58e69be6433c786c2618536dc1d1dbbdde30a461)  [`JIRAFY-6`](https://coltdorsey.atlassian.net/browse/JIRAFY-6) Image reference fix - Merge pull request #6 from coltdorsey/colt/image-reference-fix \
@@ -16,10 +18,16 @@ describe('Jirafy Sync', () => {
   * [`2616445`](http://github.com/onXmaps/jirafy-changelog/commit/26164452d005d08b01bc266abc49de2eae70260c) Update dependency @vercel/ncc to v0.33.0 - Merge pull request #10 from coltdorsey/renovate/vercel-ncc-0.x \
   * [`ce73404`](http://github.com/onXmaps/jirafy-changelog/commit/ce73404ce5cb38c9c6a86b6188a790e76a7575fb)  [`SDET-486`](https://coltdorsey.atlassian.net/browse/SDET-486) Updating references - Merge pull request #22 from onXmaps/colt/update-references'
 
+  before(() => {
+    core.setSecret('projectId')
+    projectId = process.env.PROJECT_ID
+  })
+
   context('Jira Projects', () => {
     it('Ensure jira project keys are always uppercase', async () => {
       var resp = await jira.getProjectIdByKey(key.toLowerCase())
-      chai.assert.equal(resp, process.env.PROJECT_ID)
+      chai.assert.equal(resp, process.env.PROJECT_ID || projectId)
+      core.set
     })
 
     it('Ensure project retrieval error message', async () => {
@@ -29,7 +37,7 @@ describe('Jirafy Sync', () => {
 
     it('Ensure project retrieval success', async () => {
       var resp = await jira.getProjectIdByKey(key)
-      chai.assert.equal(resp, process.env.PROJECT_ID)
+      chai.assert.equal(resp, process.env.PROJECT_ID || projectId)
     })
   })
 

--- a/test/jirafy-sync.spec.js
+++ b/test/jirafy-sync.spec.js
@@ -1,24 +1,43 @@
 require('dotenv').config()
 const jira = require('../utils/jira')
+const { parseChangelogForJiraTickets } = require('../utils/jira-helper')
 const chai = require('chai')
 const key = 'JSYNC'
 const badKey = 'arglebargle'
 
 describe('Jirafy Sync', () => {
-  context('Jira', () => {
-    it('getProjectIdByKey - Ensure jira project keys are always uppercase', async () => {
+  var changelog =
+    '* [`4f94449`](http://github.com/onXmaps/jirafy-changelog/commit/4f94449419698e134785e58ceac74702ab47781b)  [`JIRAFY-5`](https://coltdorsey.atlassian.net/browse/JIRAFY-5) Readme example release update - Merge pull request #5 from coltdorsey/colt/readme-example-release \
+  * [`58e69be`](http://github.com/onXmaps/jirafy-changelog/commit/58e69be6433c786c2618536dc1d1dbbdde30a461)  [`JIRAFY-6`](https://coltdorsey.atlassian.net/browse/JIRAFY-6) Image reference fix - Merge pull request #6 from coltdorsey/colt/image-reference-fix \
+  * [`1109803`](http://github.com/onXmaps/jirafy-changelog/commit/110980389e537555e257b5a1b07a683a3966eef8) Configure Renovate - Merge pull request #1 from coltdorsey/renovate/configure \
+  * [`76bc40f`](http://github.com/onXmaps/jirafy-changelog/commit/76bc40f804cdfe7e42d12c985576fdec21e269a8) Update coltdorsey/jirafy-changelog action to v1.1.0 - Merge pull request #8 from coltdorsey/renovate/coltdorsey-jirafy-changelog-1.x \
+  * [`af798a0`](http://github.com/onXmaps/jirafy-changelog/commit/af798a09f8f97c858c4631f760ab995889144779) Update dependency prettier to v2.5.1 - Merge pull request #13 from coltdorsey/renovate/prettier-2.x \
+  * [`802f2d5`](http://github.com/onXmaps/jirafy-changelog/commit/802f2d59003a81855c0367afe521979424d7039c) Update dependency eslint to v8.4.1 - Merge pull request #11 from coltdorsey/renovate/eslint-8.x \
+  * [`2616445`](http://github.com/onXmaps/jirafy-changelog/commit/26164452d005d08b01bc266abc49de2eae70260c) Update dependency @vercel/ncc to v0.33.0 - Merge pull request #10 from coltdorsey/renovate/vercel-ncc-0.x \
+  * [`ce73404`](http://github.com/onXmaps/jirafy-changelog/commit/ce73404ce5cb38c9c6a86b6188a790e76a7575fb)  [`SDET-486`](https://coltdorsey.atlassian.net/browse/SDET-486) Updating references - Merge pull request #22 from onXmaps/colt/update-references'
+
+  context('Jira Projects', () => {
+    it('Ensure jira project keys are always uppercase', async () => {
       var resp = await jira.getProjectIdByKey(key.toLowerCase())
       chai.assert.equal(resp, '10002')
     })
 
-    it('getProjectIdByKey - No project error', async () => {
+    it('Ensure project retrieval error message', async () => {
       var resp = await jira.getProjectIdByKey(badKey)
       chai.assert.equal(resp, `Error: No project could be found with key '${badKey.toUpperCase()}'.`)
     })
 
-    it('getProjectIdByKey - success', async () => {
+    it('Ensure project retrieval success', async () => {
       var resp = await jira.getProjectIdByKey(key)
       chai.assert.equal(resp, '10002')
+    })
+  })
+
+  context('Sync', () => {
+    it('Ensure changelog parse omits branch references', async () => {
+      parseChangelogForJiraTickets(changelog).forEach((ticket) => {
+        chai.assert.notEqual(ticket, 'eslint')
+      })
     })
   })
 })

--- a/test/jirafy-sync.spec.js
+++ b/test/jirafy-sync.spec.js
@@ -2,7 +2,7 @@ require('dotenv').config()
 const jira = require('../utils/jira')
 const { parseChangelogForJiraTickets } = require('../utils/jira-helper')
 const chai = require('chai')
-const key = 'JSYNC'
+const key = 'SDET'
 const badKey = 'arglebargle'
 
 describe('Jirafy Sync', () => {
@@ -19,7 +19,7 @@ describe('Jirafy Sync', () => {
   context('Jira Projects', () => {
     it('Ensure jira project keys are always uppercase', async () => {
       var resp = await jira.getProjectIdByKey(key.toLowerCase())
-      chai.assert.equal(resp, '10002')
+      chai.assert.equal(resp, process.env.PROJECT_ID)
     })
 
     it('Ensure project retrieval error message', async () => {
@@ -29,7 +29,7 @@ describe('Jirafy Sync', () => {
 
     it('Ensure project retrieval success', async () => {
       var resp = await jira.getProjectIdByKey(key)
-      chai.assert.equal(resp, '10002')
+      chai.assert.equal(resp, process.env.PROJECT_ID)
     })
   })
 

--- a/test/jirafy-sync.spec.js
+++ b/test/jirafy-sync.spec.js
@@ -2,7 +2,7 @@ require('dotenv').config()
 const jira = require('../utils/jira')
 const { parseChangelogForJiraTickets } = require('../utils/jira-helper')
 const chai = require('chai')
-const key = 'JSYNC'
+const key = 'SDET'
 const badKey = 'arglebargle'
 
 describe('Jirafy Sync', () => {

--- a/utils/jira-helper.js
+++ b/utils/jira-helper.js
@@ -11,7 +11,7 @@ function parseChangelogForJiraTickets(changelog) {
   var tickets
 
   try {
-    const regex = /([A-Za-z0-9]+-\d+)/g
+    const regex = /([A-Za-z0-9]+-\d+)(?=`)/g
     tickets = [...changelog.matchAll(regex)]
   } catch (error) {
     core.setFailed(error.message)


### PR DESCRIPTION
- Fix to omit parsing references to branch names in a given changelog
- Added test
- updated jirafy-changelog to v1.2.0
- updated self references to v2.1.0